### PR TITLE
Explicitly declare context path.

### DIFF
--- a/.github/workflows/push_on_commits_wo_tag.yml
+++ b/.github/workflows/push_on_commits_wo_tag.yml
@@ -51,3 +51,5 @@ jobs:
         cache_registry: ${{ env.KANIKO_CACHE_REGISTRY }}
         # Dockerfile filename
         build_file: Dockerfile
+        # Context path
+        path: .

--- a/.github/workflows/push_on_tag.yml
+++ b/.github/workflows/push_on_tag.yml
@@ -46,7 +46,9 @@ jobs:
         # Docker registry meant to be used as cache
         cache_registry: ${{ env.KANIKO_CACHE_REGISTRY }}
         # Dockerfile filename
-        build_file: ${{github.workspace}}/Dockerfile
+        build_file: Dockerfile
+        # Context path
+        path: .
     - name: build and push latest
       uses: aevea/action-kaniko@v0.6.1
       with:
@@ -65,4 +67,6 @@ jobs:
         # Docker registry meant to be used as cache
         cache_registry: ${{ env.KANIKO_CACHE_REGISTRY }}
         # Dockerfile filename
-        build_file: ${{github.workspace}}/Dockerfile
+        build_file: Dockerfile
+        # Context path
+        path: .


### PR DESCRIPTION
Fixes issue in the CI for tagged commits that was preventing it to build successfully.